### PR TITLE
Test for GET, HEAD and OPTIONS methods requirement

### DIFF
--- a/protocol/read-write-resource/read-method-support.feature
+++ b/protocol/read-write-resource/read-method-support.feature
@@ -19,4 +19,16 @@ Feature: Servers MUST support GET, HEAD and OPTIONS
     When method GET
     Then assert responseStatus != 400 && responseStatus <= 403
 
+  Scenario: HEAD is supported for containers
+    Given url testContainer.url
+    And headers clients.alice.getAuthHeaders('HEAD', testContainer.url)
+    When method HEAD
+    Then assert responseStatus != 400 && responseStatus <= 403
+
+  Scenario: HEAD is supported for resources
+    Given url rdfResource.url
+    And headers clients.alice.getAuthHeaders('HEAD', rdfResource.url)
+    When method HEAD
+    Then assert responseStatus != 400 && responseStatus <= 403
+
 # TODO: What does requirement really mean? Since authn isn't required, should we test without authn and allow 40x, or should we always test with out and require a 200 response?

--- a/protocol/read-write-resource/read-method-support.feature
+++ b/protocol/read-write-resource/read-method-support.feature
@@ -31,4 +31,18 @@ Feature: Servers MUST support GET, HEAD and OPTIONS
     When method HEAD
     Then assert responseStatus != 400 && responseStatus <= 403
 
+
+  Scenario: OPTIONS is supported for containers
+    Given url testContainer.url
+    And headers clients.alice.getAuthHeaders('OPTIONS', testContainer.url)
+    When method OPTIONS
+    Then assert responseStatus != 400 && responseStatus <= 403
+
+  Scenario: OPTIONS is supported for resources
+    Given url rdfResource.url
+    And headers clients.alice.getAuthHeaders('OPTIONS', rdfResource.url)
+    When method OPTIONS
+    Then assert responseStatus != 400 && responseStatus <= 403
+
+    
 # TODO: What does requirement really mean? Since authn isn't required, should we test without authn and allow 40x, or should we always test with out and require a 200 response?

--- a/protocol/read-write-resource/read-method-support.feature
+++ b/protocol/read-write-resource/read-method-support.feature
@@ -8,9 +8,15 @@ Feature: Servers MUST support GET, HEAD and OPTIONS
     * def expected = parse(exampleTurtle, 'text/turtle')
     
   Scenario: GET is supported for containers
-    * def containerUrl = testContainer.url
-    Given url containerUrl
-    And headers clients.alice.getAuthHeaders('GET', containerUrl)
+    Given url testContainer.url
+    And headers clients.alice.getAuthHeaders('GET', testContainer.url)
     When method GET
     Then assert responseStatus != 400 && responseStatus <= 403
 
+  Scenario: GET is supported for resources
+    Given url rdfResource.url
+    And headers clients.alice.getAuthHeaders('GET', rdfResource.url)
+    When method GET
+    Then assert responseStatus != 400 && responseStatus <= 403
+
+# TODO: What does requirement really mean? Since authn isn't required, should we test without authn and allow 40x, or should we always test with out and require a 200 response?

--- a/protocol/read-write-resource/read-method-support.feature
+++ b/protocol/read-write-resource/read-method-support.feature
@@ -1,0 +1,16 @@
+Feature: Servers MUST support GET, HEAD and OPTIONS
+
+  Background: Set up container
+    * def testContainer = rootTestContainer.createContainer()
+    * def container = testContainer.createContainer()  
+    * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
+    * def rdfResource = testContainer.createResource('.ttl', exampleTurtle, 'text/turtle');
+    * def expected = parse(exampleTurtle, 'text/turtle')
+    
+  Scenario: GET is supported for containers
+    * def containerUrl = testContainer.url
+    Given url containerUrl
+    And headers clients.alice.getAuthHeaders('GET', containerUrl)
+    When method GET
+    Then assert responseStatus != 400 && responseStatus <= 403
+

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -99,7 +99,7 @@ manifest:slug-uri-assignment
 
 manifest:read-method-support
   a td:TestCase ;
-    spec:requirementReference sopr:server-safe-methods ;
+  spec:requirementReference sopr:server-safe-methods ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/read-write-resource/read-method-support.feature> .

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -82,6 +82,7 @@ manifest:method-not-allowed
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/read-write-resource/method-not-allowed.feature> .
 
+
 manifest:post-uri-assignment
   a td:TestCase ;
     spec:requirementReference sopr:server-post-uri-assignment ;
@@ -95,4 +96,12 @@ manifest:slug-uri-assignment
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/read-write-resource/post-uri-assignment-slug.feature> .
+
+manifest:read-method-support
+  a td:TestCase ;
+    spec:requirementReference sopr:server-safe-methods ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/read-write-resource/read-method-support.feature> .
+
 


### PR DESCRIPTION
I am quite unsure how we should test the requirement that:

> Servers MUST support the HTTP GET, HEAD and OPTIONS methods [RFC7231] for clients to read resources or to determine communication options. 

What does it mean in testable terms that it "supports" that? There is a lot of other requirements that are relevant to that support, right?

So, generally, you could argue that it means that if a resource exists, you should get a `200`, but then, authorization doesn't enter the equation before the next sentence, so it could be legitimate to respond with a `401` or `403`. You could also argue that it just means that they are `Allow`ed, so you could just make sure it isn't a `405`. 

In this test, I've been strict in that it is an authentication client, but been liberal in that support means that it is not erroring in certain ways. You could also argue that it shouldn't need authn, but be liberal in the returns, or that it should be tested with authn, but then, should always return a 2xx.