### PR TITLE
Server not required to send Access-Control-Allow-Credentials

### DIFF
--- a/protocol/cors/access-control-headers.feature
+++ b/protocol/cors/access-control-headers.feature
@@ -15,7 +15,6 @@ Feature: Server must respond to requests sending Origin with the appropriate Acc
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     Examples:
       | method | headers!                       | body            | statuses |
       | GET    | {Accept: 'text/turtle'}        | def ignore = 1  | [401]    |
@@ -31,7 +30,6 @@ Feature: Server must respond to requests sending Origin with the appropriate Acc
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     Examples:
       | method | headers!                       | body            | statuses             |
       | GET    | {Accept: 'text/turtle'}        | def ignore = 1  | [200]                |

--- a/protocol/cors/preflight-requests.feature
+++ b/protocol/cors/preflight-requests.feature
@@ -31,13 +31,14 @@ Feature: Server must implement the CORS protocol for preflight requests
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     # Check Content-Type on GET request only
-    And <check>
-    And match header Vary contains 'Origin'
+    And <checkContentType>
+    # Check Vary on GET/HEAD requests only
+    And <checkVary>
     Examples:
-      | method | body            | statuses             | check                                            |
-      | GET    | def ignore = 1  | [200]                | match header Content-Type contains 'text/turtle' |
-      | HEAD   | def ignore = 1  | [200]                | def ignore = 1                                   |
-      | POST   | request "Hello" | [200, 201, 204, 205] | def ignore = 1                                   |
+      | method | body            |  | statuses             | checkContentType                                 | checkVary                           |
+      | GET    | def ignore = 1  |  | [200]                | match header Content-Type contains 'text/turtle' | match header Vary contains 'Origin' |
+      | HEAD   | def ignore = 1  |  | [200]                | def ignore = 1                                   | match header Vary contains 'Origin' |
+      | POST   | request "Hello" |  | [200, 201, 204, 205] | def ignore = 1                                   | def ignore = 1                      |
 
   @http-redirect
   Scenario: OPTIONS request returns headers for pre-flight check after redirect from http

--- a/protocol/cors/preflight-requests.feature
+++ b/protocol/cors/preflight-requests.feature
@@ -16,7 +16,6 @@ Feature: Server must implement the CORS protocol for preflight requests
     And match header Access-Control-Allow-Headers contains 'X-CUSTOM'
     And match header Access-Control-Allow-Headers contains 'Content-Type'
     And match header Access-Control-Allow-Headers contains 'Accept'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match response == ''
 
@@ -29,7 +28,6 @@ Feature: Server must implement the CORS protocol for preflight requests
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     # Check Content-Type on GET request only
@@ -62,6 +60,5 @@ Feature: Server must implement the CORS protocol for preflight requests
     And match header Access-Control-Allow-Methods contains 'POST'
     And match header Access-Control-Allow-Headers contains 'X-CUSTOM'
     And match header Access-Control-Allow-Headers contains 'Content-Type'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match response == ''

--- a/protocol/cors/preflight.feature
+++ b/protocol/cors/preflight.feature
@@ -14,7 +14,6 @@ Feature: Server must support HTTP OPTIONS for CORS preflight requests
     And match header Access-Control-Allow-Methods contains 'POST'
     And match header Access-Control-Allow-Headers contains 'X-CUSTOM'
     And match header Access-Control-Allow-Headers contains 'Content-Type'
-    And match header Access-Control-Allow-Credentials == 'true'
     # We should check the list of headers exposed but what is the required list
     And match header Access-Control-Expose-Headers != null
     And match response == ''
@@ -39,7 +38,6 @@ Feature: Server must support HTTP OPTIONS for CORS preflight requests
     And match header Access-Control-Allow-Methods contains 'POST'
     And match header Access-Control-Allow-Headers contains 'X-CUSTOM'
     And match header Access-Control-Allow-Headers contains 'Content-Type'
-    And match header Access-Control-Allow-Credentials == 'true'
     # We should check the list of headers exposed but what is the required list
     And match header Access-Control-Expose-Headers != null
     And match response == ''

--- a/protocol/cors/simple-requests.feature
+++ b/protocol/cors/simple-requests.feature
@@ -15,7 +15,6 @@ Feature: Server must implement the CORS protocol for simple requests
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     And match header Vary contains 'Origin'
@@ -33,7 +32,6 @@ Feature: Server must implement the CORS protocol for simple requests
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     And match header Vary contains 'Origin'
@@ -51,7 +49,6 @@ Feature: Server must implement the CORS protocol for simple requests
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     And match header Vary contains 'Origin'
@@ -70,7 +67,6 @@ Feature: Server must implement the CORS protocol for simple requests
     When method <method>
     Then match <statuses> contains responseStatus
     And match header Access-Control-Allow-Origin == 'https://tester'
-    And match header Access-Control-Allow-Credentials == 'true'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
     And match header Vary contains 'Origin'

--- a/protocol/cors/simple-requests.feature
+++ b/protocol/cors/simple-requests.feature
@@ -17,7 +17,6 @@ Feature: Server must implement the CORS protocol for simple requests
     And match header Access-Control-Allow-Origin == 'https://tester'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
-    And match header Vary contains 'Origin'
     Examples:
       | method | headers!                       | body            | statuses |
       | GET    | {Accept: 'text/turtle'}        | def ignore = 1  | [401]    |
@@ -34,7 +33,6 @@ Feature: Server must implement the CORS protocol for simple requests
     And match header Access-Control-Allow-Origin == 'https://tester'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
-    And match header Vary contains 'Origin'
     Examples:
       | method | headers!                       | body            | statuses |
       | GET    | {Accept: 'text/plain'}         | def ignore = 1  | [401]    |
@@ -51,12 +49,13 @@ Feature: Server must implement the CORS protocol for simple requests
     And match header Access-Control-Allow-Origin == 'https://tester'
     And match header Access-Control-Expose-Headers != null
     And match header Access-Control-Expose-Headers != '*'
-    And match header Vary contains 'Origin'
+    # Check Vary on GET/HEAD requests only
+    And <checkVary>
     Examples:
-      | method | headers!                       | body            | statuses             |
-      | GET    | {Accept: 'text/turtle'}        | def ignore = 1  | [200]                |
-      | HEAD   | {}                             | def ignore = 1  | [200]                |
-      | POST   | {'Content-Type': 'text/plain'} | request "Hello" | [200, 201, 204, 205] |
+      | method | headers!                       | body            | statuses             | checkVary                           |
+      | GET    | {Accept: 'text/turtle'}        | def ignore = 1  | [200]                | match header Vary contains 'Origin' |
+      | HEAD   | {}                             | def ignore = 1  | [200]                | match header Vary contains 'Origin' |
+      | POST   | {'Content-Type': 'text/plain'} | request "Hello" | [200, 201, 204, 205] | def ignore = 1                      |
 
   Scenario Outline: Requests resource with credentials: <method> request returns access control headers
     Given url resource.url


### PR DESCRIPTION
This PR resolves 2 issues with CORS tests:
1. `Access-Control-Allow-Credentials` was being expected when it is not required, and actually not a good thing to send so the tests no longer require it.
2. The `Vary` header was being tested for after POST requests or requests resulting in a 401 - it doesn't make sense in either situation.

Some implementations probably return some headers too often but the tests should definitely not fail when they are left off when not required.