### PR TITLE
Fix allowed status for posting to non-existent target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Use harness API to test sending requests without a content type header.
 * Ensure container created correctly on slash semantic tests.
 * Update default test subjects for latest releases.
+* For tests posting to a non-existent target, 405 is a valid response if target is not a container.
 
 ## Release 0.0.11
 * Moved repository to `solid-contrib` organization.

--- a/protocol/writing-resource/post-target-not-found.feature
+++ b/protocol/writing-resource/post-target-not-found.feature
@@ -4,7 +4,7 @@ Feature: POST to non-existing resource must result in 404
     * def testContainer = rootTestContainer.createContainer()
 
   Scenario: Reserved container does not exist
-    * def container = testContainer.reserveContainer()  
+    * def container = testContainer.reserveContainer()
     Given url container.url
     And headers clients.alice.getAuthHeaders('POST', container.url)
     And header Content-Type = 'text/turtle'
@@ -16,7 +16,7 @@ Feature: POST to non-existing resource must result in 404
     And headers clients.alice.getAuthHeaders('GET', container.url)
     When method GET
     Then status 404
-    
+
   Scenario: Reserved RDF resource does not exist
     * def rdfResource = testContainer.reserveResource('.ttl');
     Given url rdfResource.url
@@ -24,7 +24,7 @@ Feature: POST to non-existing resource must result in 404
     And header Content-Type = 'text/turtle'
     And request "<> a <#Something> ."
     When method POST
-    Then status 404
+    Then match [404, 405] contains responseStatus
 
     Given url rdfResource.url
     And headers clients.alice.getAuthHeaders('GET', rdfResource.url)
@@ -38,21 +38,21 @@ Feature: POST to non-existing resource must result in 404
     And header Content-Type = 'application/ld+json'
     And request '{ "http://schema.org/name": "Thing" }'
     When method POST
-    Then status 404
+    Then match [404, 405] contains responseStatus
 
     Given url jsonResource.url
     And headers clients.alice.getAuthHeaders('GET', jsonResource.url)
     When method GET
     Then status 404
-    
+
   Scenario: Reserved resource does not exist
     * def fooResource = testContainer.reserveResource('.foo');
     Given url fooResource.url
     And headers clients.alice.getAuthHeaders('POST', fooResource.url)
     And header Content-Type = 'foo/bar'
-    And request 'Foobar'    
+    And request 'Foobar'
     When method POST
-    Then match [404, 415] contains responseStatus
+    Then match [404, 405, 415] contains responseStatus
 
     Given url fooResource.url
     And headers clients.alice.getAuthHeaders('GET', fooResource.url)


### PR DESCRIPTION
For POST to a non-existent target the test expected a 404 but if the target is not a container then surely 405 is also valid as POST may not be supported.