### PR TITLE
Make location header fetching case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,15 +358,17 @@ The headers are available as `responseHeaders`. However, this can be tricky to u
 in the form `Map<String, List<String>>`, and it preserves the case of the returned header names even though they should
 be treated as case insensitive. Because of this, there is a shortcut `header` which matches the header name 
 case-insensitively and matches any value of that key. In the example below, the first 3 are equivalent but the 4th
-fails:
+fails. There is a new function which helps with this problem as the last example shows:
 ```gherkin
 * match header Content-Type contains 'text/turtle'
 * match header content-type contains 'text/turtle'
-* responseHeaders['Content-Type'][0] contains 'text/turtle'
-* responseHeaders['content-type'][0] contains 'text/turtle'  # fails as responseHeaders['content-type'] returns null
+* match responseHeaders['Content-Type'][0] contains 'text/turtle'
+* match responseHeaders['content-type'][0] contains 'text/turtle'  # fails as responseHeaders['content-type'] returns null
+* match karate.response.header('content-type') contains 'text/turtle'
 ```
 Note that it is safer to use `contains` instead of `==` in this case since the header value may contain an encoding
 element such as `; charset=UTF-8`.
+You can also get an array of all the values of a header with `karate.response.headerValues()`.
 
 Using the `responseStatus` variable as an alternative to `status` was mentioned earlier.
 

--- a/protocol/cors/preflight-requests.feature
+++ b/protocol/cors/preflight-requests.feature
@@ -50,7 +50,7 @@ Feature: Server must implement the CORS protocol for preflight requests
     And header Access-Control-Request-Headers = 'X-CUSTOM, Content-Type'
     When method OPTIONS
     Then match [301, 308] contains responseStatus
-    * def location = responseHeaders['Location'][0]
+    * def location = karate.response.headerValues('location')[0]
 
     Given url location
     And header Origin = 'https://tester'

--- a/protocol/cors/preflight.feature
+++ b/protocol/cors/preflight.feature
@@ -27,7 +27,7 @@ Feature: Server must support HTTP OPTIONS for CORS preflight requests
     And header Access-Control-Request-Headers = 'X-CUSTOM, Content-Type'
     When method OPTIONS
     Then match [301, 308] contains responseStatus
-    * def location = responseHeaders['Location'][0]
+    * def location = karate.response.headerValues('location')[0]
 
     Given url location
     And header Origin = 'https://tester'

--- a/protocol/writing-resource/slash-semantics-exclude.feature
+++ b/protocol/writing-resource/slash-semantics-exclude.feature
@@ -60,7 +60,7 @@ Feature: With and without trailing slash cannot co-exist
     And header Link = '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
     When method POST
     Then assert responseStatus >= 200 && responseStatus < 300
-    And def childContainerUrl = responseHeaders['Location'][0]
+    And def childContainerUrl = karate.response.headerValues('location')[0]
     And assert childContainerUrl.endsWith('/')
 
     # confirm there is no non-container resource with the same URI
@@ -87,7 +87,7 @@ Feature: With and without trailing slash cannot co-exist
     And request 'Hello'
     When method POST
     # this should either succeed (without using the slug) or fail as a conflict
-    Then assert (responseStatus >= 200 && responseStatus < 300 && responseHeaders['Location'][0] != resourceUrl) || [409, 415].includes(responseStatus)
+    Then assert (responseStatus >= 200 && responseStatus < 300 && karate.response.headerValues('location')[0] != resourceUrl) || [409, 415].includes(responseStatus)
 
   Scenario: POST resource, then try container with same name
     Given url testContainer.url
@@ -96,7 +96,7 @@ Feature: With and without trailing slash cannot co-exist
     And request 'Hello'
     When method POST
     Then assert responseStatus >= 200 && responseStatus < 300
-    And def resourceUrl = responseHeaders['Location'][0]
+    And def resourceUrl = karate.response.headerValues('location')[0]
     And assert !resourceUrl.endsWith('/')
 
     # confirm there is no container with the same URI
@@ -122,6 +122,6 @@ Feature: With and without trailing slash cannot co-exist
     And header Link = '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
     When method POST
     # this should either succeed (without using the slug) or fail as a conflict
-    Then assert (responseStatus >= 200 && responseStatus < 300 && responseHeaders['Location'][0] != resourceUrl + '/') || [409, 415].includes(responseStatus)
+    Then assert (responseStatus >= 200 && responseStatus < 300 && karate.response.headerValues('location')[0] != resourceUrl + '/') || [409, 415].includes(responseStatus)
 
 # TODO: Evil test to check various suffices.


### PR DESCRIPTION
Karate added a new feature that allows headers to be fetched in a case-insensitive way. This PR documents and applies that change so that we are less vulnerable to a server using alternative versions such as `location` rather than `Location`