### PR TITLE
Add test to check GET,HEAD,OPTIONS are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Ensure container created correctly on slash semantic tests.
 * Update default test subjects for latest releases.
 * For tests posting to a non-existent target, 405 is a valid response if target is not a container.
+* Add tests for support of read methods
 
 ## Release 0.0.11
 * Moved repository to `solid-contrib` organization.

--- a/protocol/read-write-resource/read-method-support.feature
+++ b/protocol/read-write-resource/read-method-support.feature
@@ -1,0 +1,36 @@
+Feature: Servers MUST support GET, HEAD and OPTIONS
+
+  Background: Set up container
+    * def testContainer = rootTestContainer.createContainer()
+    * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
+    * def rdfResource = testContainer.createResource('.ttl', exampleTurtle, 'text/turtle');
+
+  Scenario: GET is supported for containers
+    Given url testContainer.url
+    When method GET
+    Then assert responseStatus != 405 && responseStatus != 501
+
+  Scenario: GET is supported for resources
+    Given url rdfResource.url
+    When method GET
+    Then assert responseStatus != 405 && responseStatus != 501
+
+  Scenario: HEAD is supported for containers
+    Given url testContainer.url
+    When method HEAD
+    Then assert responseStatus != 405 && responseStatus != 501
+
+  Scenario: HEAD is supported for resources
+    Given url rdfResource.url
+    When method HEAD
+    Then assert responseStatus != 405 && responseStatus != 501
+
+  Scenario: OPTIONS is supported for containers
+    Given url testContainer.url
+    When method OPTIONS
+    Then assert responseStatus != 405 && responseStatus != 501
+
+  Scenario: OPTIONS is supported for resources
+    Given url rdfResource.url
+    When method OPTIONS
+    Then assert responseStatus != 405 && responseStatus != 501

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -176,3 +176,9 @@ manifest:cors-accept-acah
   spec:testScript
     <https://github.com/solid-contrib/specification-tests/blob/main/protocol/cors/accept-acah.feature> .
 
+manifest:read-method-support
+  a td:TestCase ;
+  spec:requirementReference sopr:server-safe-methods ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid-contrib/specification-tests/blob/main/protocol/read-write-resource/read-method-support.feature> .


### PR DESCRIPTION
This replaces https://github.com/solid-contrib/specification-tests/pull/62 as it was too difficult to merge that one but see the discussion there.