### PR TITLE
Make it clear that the dots mean CSS is starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ tests available locally.
 For each test subject you want to test, create a `{subject}.env` file in this directory according to the instructions
 [here](https://hub.docker.com/r/solidproject/conformance-test-harness).
 
+Add the following line to your `/etc/hosts` file:
+```
+127.0.0.1       server
+```
+
 To see the usage instructions:
 ```shell
 ./run.sh

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ tests available locally.
 For each test subject you want to test, create a `{subject}.env` file in this directory according to the instructions
 [here](https://hub.docker.com/r/solidproject/conformance-test-harness).
 
-Add the following line to your `/etc/hosts` file:
+If you are testing a local server, add the following line to your `/etc/hosts` file rather than use `http://localhost`:
 ```
 127.0.0.1       server
 ```

--- a/run.sh
+++ b/run.sh
@@ -90,6 +90,7 @@ EOF
     --httpsKey=/certs/server.key --httpsCert=/certs/server.cert \
     --port=443 --baseUrl=https://server/
 
+  echo 'Please wait while CSS is starting up'
   until $(curl --output /dev/null --silent --head --fail -k https://server); do
     printf '.'
     sleep 1


### PR DESCRIPTION
When I ran `./run.sh -d . css --filter=content-negotiation` I was surprised by the number of dots, at how many tests (I thought) there were in the content-negotiation category. But after reading the code of `run.sh`, I realised I had misinterpreted the dots! :) This extra console message should hopefully make that clearer.

With this change, this is what it will look like:
![Screenshot 2023-03-29 at 09 21 26](https://user-images.githubusercontent.com/408412/228457030-509715e6-ea8d-4407-9a1e-aa26dd2056b6.png)
