### PR TITLE
Add a retry mechanism for authorization tests

### DIFF
--- a/web-access-control/protected-operation/common.feature
+++ b/web-access-control/protected-operation/common.feature
@@ -9,6 +9,12 @@ Scenario:
         return agentLowerCase !== 'public' ? clients[agentLowerCase].getAuthHeaders(method, url) : {}
       }
     """
+  * def includesExpectedStatus =
+    """
+      function (actual, expected) {
+        return expected.includes(actual);
+      }
+    """
   * def getRequestData =
     """
       function (type) {

--- a/web-access-control/protected-operation/read-access-agent.feature
+++ b/web-access-control/protected-operation/read-access-agent.feature
@@ -57,7 +57,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -109,7 +109,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -136,7 +136,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/read-access-agent.feature
+++ b/web-access-control/protected-operation/read-access-agent.feature
@@ -57,7 +57,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -109,7 +109,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -136,7 +136,7 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/read-access-agent.feature
+++ b/web-access-control/protected-operation/read-access-agent.feature
@@ -18,8 +18,8 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Bob    | can    | GET     | plain     | no        | R         | 200    |
@@ -57,8 +57,8 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | PUT    | rdf       | no        | R         | [403]      |
@@ -88,8 +88,8 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/n3'
     And request '@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:insert a solid:InsertDeletePatch; solid:inserts { <> a <http://example.org#Foo> . }.'
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method | type      | container | resource  | status |
       | Bob    | cannot | PATCH  | rdf       | no        | R         | 403    |
@@ -109,8 +109,8 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
       | Bob    | cannot | PUT    | plain   | no        | R         | [403]           |
@@ -136,8 +136,8 @@ Feature: Only authenticated agents can read (and only that) a resource when gran
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | DELETE | plain     | no        | R         | [403]      |

--- a/web-access-control/protected-operation/read-access-bob.feature
+++ b/web-access-control/protected-operation/read-access-bob.feature
@@ -18,8 +18,8 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Bob    | can    | GET     | plain     | no        | R         | 200    |
@@ -57,8 +57,8 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | PUT    | rdf       | no        | R         | [403]      |
@@ -88,8 +88,8 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/n3'
     And request '@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:insert a solid:InsertDeletePatch; solid:inserts { <> a <http://example.org#Foo> . }.'
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method | type      | container | resource  | status |
       | Bob    | cannot | PATCH  | rdf       | no        | R         | 403    |
@@ -109,8 +109,8 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
       | Bob    | cannot | PUT    | plain   | no        | R         | [403]           |
@@ -136,8 +136,8 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | DELETE | plain     | no        | R         | [403]      |

--- a/web-access-control/protected-operation/read-access-bob.feature
+++ b/web-access-control/protected-operation/read-access-bob.feature
@@ -57,7 +57,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -109,7 +109,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -136,7 +136,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/read-access-bob.feature
+++ b/web-access-control/protected-operation/read-access-bob.feature
@@ -57,7 +57,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -109,7 +109,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -136,7 +136,7 @@ Feature: Only Bob can read (and only that) a resource when granted read access
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/read-access-public.feature
+++ b/web-access-control/protected-operation/read-access-public.feature
@@ -18,8 +18,8 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Bob    | can    | GET     | plain     | no        | R         | 200    |
@@ -61,8 +61,8 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | PUT    | rdf       | no        | R         | [403]      |
@@ -92,8 +92,8 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/n3'
     And request '@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:insert a solid:InsertDeletePatch; solid:inserts { <> a <http://example.org#Foo> . }.'
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method | type      | container | resource  | status |
       | Bob    | cannot | PATCH  | rdf       | no        | R         | 403    |
@@ -113,8 +113,8 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
       | Bob    | cannot | PUT    | plain   | no        | R         | [403]           |
@@ -140,8 +140,8 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
       | Bob    | cannot | DELETE | plain     | no        | R         | [403]      |

--- a/web-access-control/protected-operation/read-access-public.feature
+++ b/web-access-control/protected-operation/read-access-public.feature
@@ -61,7 +61,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -113,7 +113,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -140,7 +140,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/read-access-public.feature
+++ b/web-access-control/protected-operation/read-access-public.feature
@@ -61,7 +61,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this.".'
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |
@@ -113,7 +113,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = 'text/plain'
     And request "Bob's text"
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type    | container | resource  | status          |
@@ -140,7 +140,7 @@ Feature: Public agents can read (and only that) a resource when granted read acc
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status     |

--- a/web-access-control/protected-operation/write-access-agent.feature
+++ b/web-access-control/protected-operation/write-access-agent.feature
@@ -58,7 +58,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -94,7 +94,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -123,7 +123,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     * def testResource = utils.createResource(container, resource, type, 'authenticated')
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |

--- a/web-access-control/protected-operation/write-access-agent.feature
+++ b/web-access-control/protected-operation/write-access-agent.feature
@@ -14,7 +14,6 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
       | 'container' | 'WAC'     | 'inherited' |
     * def utils = callonce read('common.feature') ({resources, subject: 'authenticated'})
 
-    @ignore
   Scenario Outline: <agent> <result> read a <type> resource (<method>), when an authenticated agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
@@ -52,7 +51,6 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
       | Public | cannot | HEAD    | container | no        | WAC       | 401    |
       | Public | cannot | HEAD    | container | WAC       | inherited | 401    |
 
-  @ignore
   Scenario Outline: <agent> <result> write a <type> resource (<method>) and cannot read it, when an authenticated agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.createResource(container, resource, type, 'authenticated')
     * def requestData = utils.getRequestData(type)
@@ -60,7 +58,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until karate.match(<writeStatus>, responseStatus).pass
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -89,7 +87,6 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
       | Public | cannot | POST   | container | no        | WAC       | [401]                | 401        |
       | Public | cannot | POST   | container | WAC       | inherited | [401]                | 401        |
 
-  @ignore
   Scenario Outline: <agent> <result> <method> to a <type> resource, when an authenticated agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.createResource(container, resource, type, 'authenticated')
     * def requestData = utils.getRequestData('text/n3')
@@ -97,7 +94,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until karate.match(<writeStatus>, responseStatus).pass
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -124,17 +121,10 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
 
   Scenario Outline: <agent> <result> <method> a <type> resource, when an authenticated agent has <container> access to the container and <resource> access to the resource
 
-    * def hasExpectedStatus =
-    """
-    function(status, expected) {
-      return expected.includes(status)
-    }
-    """
-
     * def testResource = utils.createResource(container, resource, type, 'authenticated')
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until hasExpectedStatus(responseStatus, <status>)
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |

--- a/web-access-control/protected-operation/write-access-agent.feature
+++ b/web-access-control/protected-operation/write-access-agent.feature
@@ -154,4 +154,5 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
       | Public | cannot | DELETE | fictive   | WAC       | inherited | [401]                |
       | Public | cannot | DELETE | rdf       | no        | WAC       | [401]                |
       | Public | cannot | DELETE | rdf       | WAC       | inherited | [401]                |
-      | Public | cannot | DELETE | container | no        | WAC       | [401]
+      | Public | cannot | DELETE | container | no        | WAC       | [401]                |
+      | Public | cannot | DELETE | container | WAC       | inherited | [401]                |

--- a/web-access-control/protected-operation/write-access-agent.feature
+++ b/web-access-control/protected-operation/write-access-agent.feature
@@ -18,8 +18,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Bob    | cannot | GET     | plain     | no        | WAC       | 403    |
@@ -58,15 +58,15 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
 
     Given headers utils.authHeaders('GET', testResource.url, agent)
+    And retry until responseStatus == <readStatus>
     When method GET
-    Then status <readStatus>
 
     Examples:
       | agent  | result | method | type      | container | resource  | writeStatus          | readStatus |
@@ -94,15 +94,15 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
 
     Given headers utils.authHeaders('GET', testResource.url, agent)
+    And retry until responseStatus == <readStatus>
     When method GET
-    Then status <readStatus>
 
     Examples:
       | agent  | result | method | type    | container | resource  | writeStatus          | readStatus |
@@ -123,8 +123,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     * def testResource = utils.createResource(container, resource, type, 'authenticated')
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status               |
       | Bob    | cannot | DELETE | plain     | no        | C         | [403]                |

--- a/web-access-control/protected-operation/write-access-bob.feature
+++ b/web-access-control/protected-operation/write-access-bob.feature
@@ -18,8 +18,8 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Bob    | cannot | GET     | plain     | no        | WAC       | 403    |
@@ -58,15 +58,15 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
 
     Given headers utils.authHeaders('GET', testResource.url, agent)
+    And retry until responseStatus == <readStatus>
     When method GET
-    Then status <readStatus>
 
     Examples:
       | agent  | result | method | type      | container | resource  | writeStatus          | readStatus |
@@ -94,15 +94,15 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
 
     Given headers utils.authHeaders('GET', testResource.url, agent)
+    And retry until responseStatus == <readStatus>
     When method GET
-    Then status <readStatus>
 
     Examples:
       | agent  | result | method | type    | container | resource  | writeStatus          | readStatus |
@@ -123,8 +123,8 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     * def testResource = utils.createResource(container, resource, type, 'agent', webIds.bob)
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status               |
       | Bob    | cannot | DELETE | plain     | no        | C         | [403]                |

--- a/web-access-control/protected-operation/write-access-bob.feature
+++ b/web-access-control/protected-operation/write-access-bob.feature
@@ -58,7 +58,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -94,7 +94,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -123,7 +123,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     * def testResource = utils.createResource(container, resource, type, 'agent', webIds.bob)
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |

--- a/web-access-control/protected-operation/write-access-bob.feature
+++ b/web-access-control/protected-operation/write-access-bob.feature
@@ -58,7 +58,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until match <writeStatus> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -94,7 +94,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     And headers utils.authHeaders(method, testResource.url, agent)
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until match <writeStatus> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -123,7 +123,7 @@ Feature: Only Bob can write (and only that) a resource when granted write access
     * def testResource = utils.createResource(container, resource, type, 'agent', webIds.bob)
     Given url testResource.url
     And headers utils.authHeaders(method, testResource.url, agent)
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |

--- a/web-access-control/protected-operation/write-access-public.feature
+++ b/web-access-control/protected-operation/write-access-public.feature
@@ -43,7 +43,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until match <writeStatus> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -71,7 +71,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until match <writeStatus> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <writeStatus>)
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -96,7 +96,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
   Scenario Outline: <agent> <result> <method> a <type> resource, when a public agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.createResource(container, resource, type, 'public')
     Given url testResource.url
-    And retry until match <status> contains responseStatus
+    And retry until utils.includesExpectedStatus(responseStatus, <status>)
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |

--- a/web-access-control/protected-operation/write-access-public.feature
+++ b/web-access-control/protected-operation/write-access-public.feature
@@ -17,8 +17,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
   Scenario Outline: <agent> <result> read a <type> resource (<method>), when a public agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.testResources[utils.getResourceKey(container, resource, type)]
     Given url testResource.url
+    And retry until responseStatus == <status>
     When method <method>
-    Then status <status>
     Examples:
       | agent  | result | method  | type      | container | resource  | status |
       | Public | cannot | GET     | plain     | no        | WAC       | 401    |
@@ -43,8 +43,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
@@ -71,8 +71,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
+    And retry until <writeStatus> contains responseStatus
     When method <method>
-    Then match <writeStatus> contains responseStatus
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
     And match responseString !contains requestData.responseShouldNotContain
@@ -96,8 +96,8 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
   Scenario Outline: <agent> <result> <method> a <type> resource, when a public agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.createResource(container, resource, type, 'public')
     Given url testResource.url
+    And retry until <status> contains responseStatus
     When method <method>
-    Then match <status> contains responseStatus
     Examples:
       | agent  | result | method | type      | container | resource  | status               |
       | Public | cannot | DELETE | plain     | no        | C         | [401]                |

--- a/web-access-control/protected-operation/write-access-public.feature
+++ b/web-access-control/protected-operation/write-access-public.feature
@@ -43,7 +43,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -71,7 +71,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
     Given url testResource.url
     And header Content-Type = requestData.contentType
     And request requestData.requestBody
-    And retry until <writeStatus> contains responseStatus
+    And retry until match <writeStatus> contains responseStatus
     When method <method>
     # Server may return payload with information about the operation e.g. "Created" so check it hasn't leaked the data which was PUT
     And string responseString = response
@@ -96,7 +96,7 @@ Feature: Only authenticated agents can write (and only that) a resource when gra
   Scenario Outline: <agent> <result> <method> a <type> resource, when a public agent has <container> access to the container and <resource> access to the resource
     * def testResource = utils.createResource(container, resource, type, 'public')
     Given url testResource.url
-    And retry until <status> contains responseStatus
+    And retry until match <status> contains responseStatus
     When method <method>
     Examples:
       | agent  | result | method | type      | container | resource  | status               |


### PR DESCRIPTION
Some Solid server implementations may propagate access policies asynchronously. In those cases, it would be useful for the test suite to make use of Karate's `retry until` mechanism.

For simple cases where the retry matches a _particular_ status code, the code for this is trivial:

    And retry until responseStatus == <status>

In cases where a range of possible response status codes are possible, we needed to wrap the condition in a shared function, which is called `utils.includesExpectedStatus(actual, expected)`

For those cases, the condition becomes:

    And retry until utils.includesExpectedStatus(responseStatus, <status>)


